### PR TITLE
Add Auxiliary context data

### DIFF
--- a/gc/benchmark/CMakeLists.txt
+++ b/gc/benchmark/CMakeLists.txt
@@ -1,4 +1,5 @@
 add_executable(omtalk-gc-bench
+    bench-allocate.cpp
     bench-forwarding.cpp
     bench-markmap.cpp
     main.cpp

--- a/gc/benchmark/bench-allocate.cpp
+++ b/gc/benchmark/bench-allocate.cpp
@@ -1,0 +1,29 @@
+#include <benchmark/benchmark.h>
+#include <example/Object.h>
+#include <omtalk/GlobalCollector.h>
+#include <omtalk/Handle.h>
+#include <omtalk/MemoryManager.h>
+
+using namespace omtalk;
+using namespace omtalk::gc;
+
+static void BM_Allocate(benchmark::State &state) {
+
+  static auto mm =
+      MemoryManagerBuilder<TestCollectorScheme>()
+          .withRootWalker(std::make_unique<RootWalker<TestCollectorScheme>>())
+          .build();
+
+  Context<TestCollectorScheme> context(mm);
+
+  for (auto _ : state) {
+    HandleScope scope = context.getAuxData().rootScope.createScope();
+    auto ref = allocateTestStructObject(context, 10);
+    Handle<TestStructObject> handle(scope, ref);
+    context.yieldForGC();
+  }
+}
+BENCHMARK(BM_Allocate);
+BENCHMARK(BM_Allocate)->Threads(2);
+BENCHMARK(BM_Allocate)->Threads(4);
+BENCHMARK(BM_Allocate)->Threads(8);

--- a/gc/include/omtalk/GlobalCollector.h
+++ b/gc/include/omtalk/GlobalCollector.h
@@ -101,6 +101,9 @@ public:
   void sweep(Context &context) noexcept;
   // @}
 
+  /// Get the MemoryManager
+  MemoryManager<S> *getMemoryManager() { return memoryManager; }
+
   /// Get the global workstack.
   WorkStack<S> &getStack() { return stack; }
 
@@ -116,6 +119,8 @@ class GlobalCollectorContext {
 public:
   explicit GlobalCollectorContext(GlobalCollector<S> *collector)
       : collector(collector) {}
+
+  MemoryManager<S> &getMemoryManager() { return *collector->getMemoryManager(); }
 
   GlobalCollector<S> &getCollector() { return *collector; }
 

--- a/gc/test/test-compact.cpp
+++ b/gc/test/test-compact.cpp
@@ -26,7 +26,8 @@ TEST_CASE("Compact Root Fixup", "[garbage collector]") {
   auto &gcContext = context.getCollectorContext();
 
   // get the region where the object was allocated
-  HandleScope scope = mm.getRootWalker().rootScope.createScope();
+  
+  HandleScope scope = context.getAuxData().rootScope.createScope();
   auto ref = allocateTestStructObject(context, 3);
   ref->setSlot(0, {INT, 4});
   ref->setSlot(1, {INT, 5});
@@ -60,7 +61,7 @@ TEST_CASE("Compact Load Barrier", "[garbage collector]") {
   Context<TestCollectorScheme> context(mm);
   auto &gcContext = context.getCollectorContext();
 
-  HandleScope scope = mm.getRootWalker().rootScope.createScope();
+  HandleScope scope = context.getAuxData().rootScope.createScope();
   auto ref = allocateTestStructObject(context, 1);
   Handle<TestStructObject> handle(scope, ref);
 

--- a/gc/test/test-gc.cpp
+++ b/gc/test/test-gc.cpp
@@ -38,7 +38,7 @@ TEST_CASE("Allocate single root", "[garbage collector]") {
           .build();
 
   Context<TestCollectorScheme> context(mm);
-  HandleScope scope = mm.getRootWalker().rootScope.createScope();
+  HandleScope scope = context.getAuxData().rootScope.createScope();
   auto ref = allocateTestStructObject(context, 10);
   Handle<TestStructObject> handle(scope, ref);
 }
@@ -50,7 +50,7 @@ TEST_CASE("Allocate Cache Flushing", "[garbage collector]") {
           .build();
 
   Context<TestCollectorScheme> context(mm);
-  HandleScope scope = mm.getRootWalker().rootScope.createScope();
+  HandleScope scope = context.getAuxData().rootScope.createScope();
   auto allocSize = TestStructObject::allocSize(10);
   auto ref = allocateTestStructObject(context, 10);
   auto *region = Region::get(ref);
@@ -83,7 +83,7 @@ TEST_CASE("Allocate single root and gc", "[garbage collector]") {
           .withRootWalker(std::make_unique<RootWalker<TestCollectorScheme>>())
           .build();
   Context<TestCollectorScheme> context(mm);
-  HandleScope scope = mm.getRootWalker().rootScope.createScope();
+  HandleScope scope = context.getAuxData().rootScope.createScope();
   auto ref = allocateTestStructObject(context, 10);
   Handle<TestStructObject> handle(scope, ref);
   mm.collect(context);
@@ -95,7 +95,7 @@ TEST_CASE("Allocate object tree and gc", "[garbage collector]") {
           .withRootWalker(std::make_unique<RootWalker<TestCollectorScheme>>())
           .build();
   Context<TestCollectorScheme> context(mm);
-  HandleScope scope = mm.getRootWalker().rootScope.createScope();
+  HandleScope scope = context.getAuxData().rootScope.createScope();
   Handle<TestStructObject> handle(scope, allocateTestStructObject(context, 10));
 
   auto ref = allocateTestStructObject(context, 10);
@@ -111,9 +111,8 @@ TEST_CASE("Root scanning", "[garbage collector]") {
           .withRootWalker(std::make_unique<RootWalker<TestCollectorScheme>>())
           .build();
 
-  HandleScope scope = mm.getRootWalker().rootScope.createScope();
-
   Context<TestCollectorScheme> context(mm);
+  HandleScope scope = context.getAuxData().rootScope.createScope();
 
   for (int i = 0; i < 1; i++) {
     auto ref = allocateTestStructObject(context, 10);
@@ -132,7 +131,7 @@ TEST_CASE("Concurrent", "[garbage collector]") {
   Context<TestCollectorScheme> context(mm);
   auto &gcContext = context.getCollectorContext();
 
-  HandleScope scope = mm.getRootWalker().rootScope.createScope();
+  HandleScope scope = context.getAuxData().rootScope.createScope();
   unsigned nslots = 10;
   auto ref = allocateTestStructObject(context, nslots);
   Handle<TestStructObject> handle(scope, ref);

--- a/gc/test/test-mark.cpp
+++ b/gc/test/test-mark.cpp
@@ -24,7 +24,7 @@ TEST_CASE("Mark Roots", "[garbage collector]") {
   auto &gcContext = context.getCollectorContext();
 
   // get the region where the object was allocated
-  HandleScope scope = mm.getRootWalker().rootScope.createScope();
+  HandleScope scope = context.getAuxData().rootScope.createScope();
   auto ref = allocateTestStructObject(context, 1);
   Handle<TestStructObject> handle(scope, ref);
   auto *region = Region::get(handle.get());
@@ -59,7 +59,7 @@ TEST_CASE("Mark Object Graph", "[garbage collector]") {
   auto &gcContext = context.getCollectorContext();
 
   // Allocate root
-  HandleScope scope = mm.getRootWalker().rootScope.createScope();
+  HandleScope scope = context.getAuxData().rootScope.createScope();
   auto ref = allocateTestStructObject(context, 1);
   Handle<TestStructObject> root(scope, ref);
 
@@ -95,7 +95,7 @@ TEST_CASE("Check live data", "[garbage collector]") {
   Context<TestCollectorScheme> context(mm);
   auto &gcContext = context.getCollectorContext();
 
-  HandleScope scope = mm.getRootWalker().rootScope.createScope();
+  HandleScope scope = context.getAuxData().rootScope.createScope();
   unsigned nslots = 10;
   auto allocSize = TestStructObject::allocSize(nslots);
 
@@ -132,7 +132,7 @@ TEST_CASE("Object Allocation", "[garbage collector]") {
   Context<TestCollectorScheme> context(mm);
   auto &gcContext = context.getCollectorContext();
 
-  HandleScope scope = mm.getRootWalker().rootScope.createScope();
+  HandleScope scope = context.getAuxData().rootScope.createScope();
   unsigned nslots = 10;
   auto allocSize = TestStructObject::allocSize(nslots);
 


### PR DESCRIPTION
- add auxiliary language data to context
- add auxiliary language data to memory manager
- in example, use a per context root scope
- add multithreaded allocation benchmark
