### PR TITLE
Add OMTALK_SAN_THREADSAFETY

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -127,6 +127,10 @@ om_add_option(OMTALK_SAN_TSAN OMTALK_OPTIONS
 	CONFLICTS OMTALK_SAN_ASAN
 )
 
+om_add_option(OMTALK_SAN_THREADSAFETY OMTALK_OPTIONS
+	DOC "Build with clang thread safety annotations enabled."
+)
+
 om_add_option(OMTALK_SAN_UBSAN OMTALK_OPTIONS
 	DOC "Build with clang undefined behaviour sanitizer."
 	REQUIRES OM_HAVE_UBSAN

--- a/cmake/modules/AddOmtalk.cmake
+++ b/cmake/modules/AddOmtalk.cmake
@@ -5,6 +5,11 @@ set(ADD_OMTALK_ TRUE)
 
 # Add omtalk specific build options to a target.
 function(add_omtalk_target target)
+	target_compile_definitions(${target}
+		PUBLIC
+			${OMTALK_COMPILE_DEFINITIONS}
+	)
+
 	target_compile_options(${target}
 		PUBLIC
 			${OMTALK_COMPILE_OPTIONS}

--- a/cmake/modules/HandleOmtalkOptions.cmake
+++ b/cmake/modules/HandleOmtalkOptions.cmake
@@ -83,6 +83,19 @@ if(OMTALK_SAN_UBSAN)
 	)
 endif()
 
+if(OMTALK_SAN_THREADSAFETY)
+	list(APPEND OMTALK_COMPILE_OPTIONS
+		$<$<COMPILE_LANGUAGE:CXX,C>:-Wthread-safety>
+	)
+	# TODO: Not all of the standard library has been annoted, only certain
+	# pieces.  This creates false errors which are impossible to fix.  In
+	# particular we need std::unique_lock to receive annotations.
+	#
+	# list(APPEND OMTALK_COMPILE_DEFINITIONS
+	# 	_LIBCPP_ENABLE_THREAD_SAFETY_ANNOTATIONS
+	# )
+endif()
+
 ###
 ### RTTI and Exceptions
 ###


### PR DESCRIPTION
This is to add the option to build with thread safety annotations for
omtalk.  They default to disabled.  In order to use these annotations
most effectively the standard library should be annotated as well.
Currently libc++ is partially annotated.