### PR TITLE
Add shorthand for mutex capability

### DIFF
--- a/util/include/omtalk/Util/Annotations.h
+++ b/util/include/omtalk/Util/Annotations.h
@@ -66,6 +66,10 @@
 #define OMTALK_CAPABILITY(x)
 #endif
 
+/// OMTALK_MUTEX_CAPABILITY
+/// Mark a class as having the mutex capability for thread safety annotations.
+#define OMTALK_MUTEX_CAPABILITY OMTALK_CAPABILITY("mutex")
+
 /// OMTALK_SCOPED_CAPABILITY
 #if OMTALK_HAS_ATTRIBUTE(scoped_lockable)
 #define OMTALK_SCOPED_CAPABILITY OMTALK_THREAD_ANNOTATION(scoped_lockable)


### PR DESCRIPTION
Adding this capability shorthand makes it more similar to
OMTALK_SCOPED_CAPABILITY, which improves readability.
