### PR TITLE
Add MutatorMutex to pause mutators

### DIFF
--- a/gc/CMakeLists.txt
+++ b/gc/CMakeLists.txt
@@ -1,6 +1,7 @@
 
 add_omtalk_library(omtalk-gc
     src/MemoryManager.cpp
+    src/MutatorMutex.cpp
 )
 
 target_include_directories(omtalk-gc

--- a/gc/include/omtalk/MutatorMutex.h
+++ b/gc/include/omtalk/MutatorMutex.h
@@ -1,0 +1,117 @@
+#ifndef OMTALK_MUTATOR_MUTEX_H
+#define OMTALK_MUTATOR_MUTEX_H
+
+#include <condition_variable>
+#include <cstdint>
+#include <mutex>
+#include <omtalk/Util/Annotations.h>
+
+namespace omtalk::gc {
+
+/// Private mutex data
+struct MutatorMutexData {
+  /// 0 indicates shared state
+  /// 1 indicates exclusive state
+  std::uint8_t state;
+  std::uintptr_t count;
+};
+
+/// Provides functionality similiar to a reader/writer lock.  Mutators all have
+/// shared access to the mutex.  When exclusive access is requested all mutator
+/// threads should advance to the next GC safepoint and yield.
+class OMTALK_MUTEX_CAPABILITY MutatorMutex {
+public:
+  MutatorMutex() noexcept {}
+
+  ~MutatorMutex() noexcept {}
+
+  /// Attach a running mutator
+  void attach() noexcept OMTALK_ACQUIRE_SHARED() {
+    std::unique_lock lock(mutex);
+    auto check = [this] { return data.state == 0; };
+    yieldCV.wait(lock, check);
+    data.count++;
+  }
+
+  /// Detach a running mutator
+  void detach() noexcept OMTALK_RELEASE_SHARED() {
+    std::unique_lock lock(mutex);
+    data.count--;
+    if (data.count == 0) {
+      requestCV.notify_all();
+    }
+  }
+
+  /// Yield shared access and block until shared access is regained.
+  bool yield() noexcept {
+    if (!requested()) {
+      return false;
+    }
+    std::unique_lock lock(mutex);
+    data.count--;
+    if (data.count == 0) {
+      requestCV.notify_all();
+    }
+    auto check = [this] { return data.state == 0; };
+    yieldCV.wait(lock, check);
+    data.count++;
+    return true;
+  }
+
+  /// Returns true if access was requested.
+  bool requested() noexcept {
+    std::scoped_lock lock(mutex);
+    return data.state;
+  }
+
+  /// Return the attached count
+  std::uintptr_t count() noexcept {
+    std::scoped_lock lock(mutex);
+    return data.count;
+  }
+
+  /// Acquire exclusive access, causing all mutators to pause.  Will block until
+  /// all mutators are paused.
+  void lock() noexcept OMTALK_ACQUIRE() {
+    std::unique_lock lock(mutex);
+    data.state = 1;
+    requestCV.wait(lock, [this] { return data.count == 0; });
+  }
+
+  /// Release exclusive access, causing all mutators to resume.
+  void unlock() noexcept OMTALK_RELEASE() {
+    std::scoped_lock lock(mutex);
+    data.state = 0;
+    yieldCV.notify_all();
+  }
+
+  MutatorMutexData *getData() { return &data; }
+
+private:
+  std::mutex mutex;
+  MutatorMutexData data = {0, 0};
+  std::condition_variable yieldCV;
+  std::condition_variable requestCV;
+};
+
+/// Requests to pause all mutator threads.
+class OMTALK_SCOPED_CAPABILITY MutatorLock {
+public:
+  MutatorLock(MutatorMutex &mutex) noexcept OMTALK_ACQUIRE(mutex)
+      : mutex(mutex) {
+    lock();
+  }
+
+  ~MutatorLock() noexcept OMTALK_RELEASE() { unlock(); }
+
+  void lock() noexcept OMTALK_ACQUIRE() { mutex.lock(); }
+
+  void unlock() noexcept OMTALK_RELEASE() { mutex.unlock(); }
+
+private:
+  MutatorMutex &mutex;
+};
+
+} // namespace omtalk::gc
+
+#endif

--- a/gc/src/MutatorMutex.cpp
+++ b/gc/src/MutatorMutex.cpp
@@ -1,0 +1,6 @@
+#include <omtalk/MutatorMutex.h>
+#include <type_traits>
+
+using namespace omtalk::gc;
+
+static_assert(std::is_standard_layout_v<MutatorMutexData>);

--- a/gc/test/CMakeLists.txt
+++ b/gc/test/CMakeLists.txt
@@ -1,13 +1,14 @@
 add_omtalk_executable(omtalk-gc-test
+	test-compact.cpp
 	test-dispatcher.cpp
 	test-exclusive.cpp
 	test-forwarding.cpp
 	test-gc.cpp
 	test-handle.cpp
 	test-mark.cpp
+	test-mutatormutex.cpp
 	test-regions.cpp
 	test-startup.cpp
-	test-compact.cpp
 )
 
 target_link_libraries(omtalk-gc-test

--- a/gc/test/test-mutatormutex.cpp
+++ b/gc/test/test-mutatormutex.cpp
@@ -1,0 +1,43 @@
+#include <catch2/catch.hpp>
+#include <omtalk/MutatorMutex.h>
+#include <thread>
+
+using namespace omtalk::gc;
+
+TEST_CASE("MutatorMutex no request", "[garbage collector]") {
+
+  MutatorMutex m;
+  REQUIRE(m.requested() == false);
+  m.attach();
+  REQUIRE(m.requested() == false);
+  m.detach();
+  REQUIRE(m.requested() == false);
+}
+
+TEST_CASE("MutatorMutex request", "[garbage collector]") {
+  MutatorMutex m;
+  m.lock();
+  std::thread thread([&m] {
+    m.attach();
+    m.detach();
+  });
+  m.unlock();
+  thread.join();
+}
+
+TEST_CASE("MutatorLock requested", "[garbage collector]") {
+  MutatorMutex m;
+  MutatorLock l(m);
+  REQUIRE(m.requested());
+}
+
+TEST_CASE("MutatorLock request", "[garbage collector]") {
+  MutatorMutex m;
+  MutatorLock l(m);
+  std::thread thread([&m] {
+    m.attach();
+    m.detach();
+  });
+  l.unlock();
+  thread.join();
+}


### PR DESCRIPTION
MutatorMutex is intended to keep track of mutators which are not
currently at safe points, and provide the GC with the capability to
signal an exclusive request.

There is no shared_lock provided for attaching and detaching access
through the mutator.
