### PR TITLE
Swap the order of the visitor and context arguments for walk

### DIFF
--- a/om/gc/include/om/GC/Scheme.h
+++ b/om/gc/include/om/GC/Scheme.h
@@ -79,7 +79,7 @@ struct Walk {
   template <typename ContextT, typename VisitorT>
   void operator()(ContextT &cx, ObjectProxy<S> target,
                   VisitorT &visitor) const noexcept {
-    target.walk(cx, visitor);
+    target.walk(visitor, cx);
   }
 };
 

--- a/om/om/CMakeLists.txt
+++ b/om/om/CMakeLists.txt
@@ -25,7 +25,7 @@ if(OM_WARNINGS)
   )
 endif()
 
-if (OMTALK_TEST)
+if(OM_TEST)
   add_executable(om-objectmodel-test
     test/test-objectmodel.cpp
     test/test-structbuilder.cpp

--- a/om/om/include/om/Om/Array.h
+++ b/om/om/include/om/Om/Array.h
@@ -26,14 +26,14 @@ struct Array {
 
   std::size_t size() const noexcept { return allocSize(elementType(), length); }
 
-  template <typename ContextT, typename VisitorT>
-  void walk(ContextT &context, VisitorT &visitor) noexcept {
-    header.walk(context, visitor);
+  template <typename VisitorT, typename... Args>
+  void walk(VisitorT &visitor, Args... args) noexcept {
+    header.walk(visitor, args...);
     if (elementType() == Type::ref) {
       std::uintptr_t *ptr = data;
       std::uintptr_t *end = data + length;
       while (ptr < end) {
-        visitor.visit(context, SlotProxy::fromPtr(ptr));
+        visitor.visit(SlotProxy::fromPtr(ptr), args...);
         ++ptr;
       }
     }

--- a/om/om/include/om/Om/Global.h
+++ b/om/om/include/om/Om/Global.h
@@ -15,9 +15,9 @@ public:
 
   gc::Ref<MetaLayout> loadMetaLayout(Context &context) noexcept;
 
-  template <typename ContextT, typename VisitorT>
-  void walk(ContextT &context, VisitorT &visitor) {
-    visitor.visit(context, gc::RefProxy(&metaLayout));
+  template <typename VisitorT, typename... Args>
+  void walk(VisitorT &visitor, Args... args) {
+    visitor.visit(gc::RefProxy(&metaLayout), args...);
   }
 
   gc::Ref<MetaLayout> metaLayout;

--- a/om/om/include/om/Om/ObjectHeader.h
+++ b/om/om/include/om/Om/ObjectHeader.h
@@ -41,8 +41,8 @@ public:
 
   inline ObjectHeaderProxy proxy() noexcept;
 
-  template <typename C, typename V>
-  void walk(C &cx, V &visitor) noexcept;
+  template <typename VisitorT, typename... Args>
+  void walk(VisitorT &visitor, Args... args) noexcept;
 
 private:
   friend class ObjectHeaderProxy;
@@ -79,9 +79,9 @@ inline ObjectHeaderProxy ObjectHeader::proxy() noexcept {
   return ObjectHeaderProxy(this);
 }
 
-template <typename C, typename V>
-void ObjectHeader::walk(C &cx, V &visitor) noexcept {
-  visitor.visit(cx, proxy());
+template <typename VisitorT, typename... Args>
+void ObjectHeader::walk(VisitorT &visitor, Args... args) noexcept {
+  visitor.visit(proxy(), args...);
 }
 
 } // namespace om::om

--- a/om/om/include/om/Om/ObjectProxy.h
+++ b/om/om/include/om/Om/ObjectProxy.h
@@ -19,6 +19,8 @@ struct ObjectProxy {
 
   gc::Ref<void> asRef() const noexcept { return target.reinterpret<void>(); }
 
+  constexpr operator void *() const noexcept { return target.get(); }
+
   std::size_t getSize() const noexcept {
     switch (target->type()) {
     case ObjectType::STRUCT:
@@ -34,19 +36,19 @@ struct ObjectProxy {
     }
   }
 
-  template <typename C, typename V>
-  void walk(C &cx, V &visitor) const noexcept {
+  template <typename VisitorT, typename... Args>
+  void walk(VisitorT &visitor, Args... args) const noexcept {
     switch (target->type()) {
     case ObjectType::STRUCT:
-      return target->as<Struct>().walk(cx, visitor);
+      return target->as<Struct>().walk(visitor, args...);
     case ObjectType::ARRAY:
-      return target->as<Array>().walk(cx, visitor);
+      return target->as<Array>().walk(visitor, args...);
     case ObjectType::STRUCT_LAYOUT:
-      return target->as<StructLayout>().walk(cx, visitor);
+      return target->as<StructLayout>().walk(visitor, args...);
     case ObjectType::ARRAY_LAYOUT:
-      return target->as<ArrayLayout>().walk(cx, visitor);
+      return target->as<ArrayLayout>().walk(visitor, args...);
     case ObjectType::META_LAYOUT:
-      return target->as<MetaLayout>().walk(cx, visitor);
+      return target->as<MetaLayout>().walk(visitor, args...);
     }
   }
 

--- a/om/om/include/om/Om/Struct.h
+++ b/om/om/include/om/Om/Struct.h
@@ -55,12 +55,13 @@ struct Struct {
 
   StructSlotSpan slots() noexcept;
 
-  template <typename ContextT, typename VisitorT>
-  void walk(ContextT &context, VisitorT &visitor) {
-    header.walk(context, visitor);
+  template <typename VisitorT, typename... Args>
+  void walk(VisitorT &visitor, Args &&...args) {
+    header.walk(visitor, std::forward<Args>(args)...);
     for (auto decl : layout().slotDeclSpan()) {
       if (decl.type == Type::ref) {
-        visitor.visit(context, SlotProxy::fromPtr(data + decl.offset));
+        visitor.visit(SlotProxy::fromPtr(data + decl.offset),
+                      std::forward<Args>(args)...);
       }
     }
   }

--- a/om/om/include/om/Om/StructLayoutBuilder.h
+++ b/om/om/include/om/Om/StructLayoutBuilder.h
@@ -2,7 +2,7 @@
 #define OM_OM_STRUCTBUILDER_H
 
 #include <ab/Util/Bytes.h>
-#include <om/Om/ObjectModel.h>
+#include <om/Om/ObjectProxy.h>
 #include <om/Om/StructLayout.h>
 #include <om/Om/Type.h>
 
@@ -21,7 +21,7 @@ public:
 
   template <Type T>
   StructLayoutBuilder &add() {
-    offset = align(offset, alignment<T>);
+    offset = ab::align(offset, alignment<T>);
     fields.push_back({offset, T});
     offset = offset + size<T>;
     return *this;

--- a/om/om/src/om-om-dummy.cpp
+++ b/om/om/src/om-om-dummy.cpp
@@ -1,4 +1,6 @@
 #include <om/Om/Allocate.h>
+#include <om/Om/Context.h>
+#include <om/Om/MemoryManager.h>
 #include <om/Om/Scheme.h>
 
 int om_om_dummy() { return 0; }

--- a/om/om/test/test-objectmodel.cpp
+++ b/om/om/test/test-objectmodel.cpp
@@ -1,4 +1,11 @@
-#include <om/Om/ObjectModel.h>
-
+#include <ab/Util/Atomic.h>
 #include <catch2/catch.hpp>
-#include <om/Util/Atomic.h>
+#include <om/Om/MemoryManager.h>
+#include <om/Om/ObjectProxy.h>
+
+TEST_CASE("Object Model", "[adfadsf]") {
+  auto mm = om::gc::MemoryManagerBuilder<om::om::Scheme>()
+                .withRootWalker(
+                    std::make_unique<om::gc::RootWalker<om::om::Scheme>>())
+                .build();
+}

--- a/om/om/test/test-structbuilder.cpp
+++ b/om/om/test/test-structbuilder.cpp
@@ -1,1 +1,1 @@
-#include <om/Om/StructBuilder.h>
+#include <om/Om/StructLayoutBuilder.h>


### PR DESCRIPTION
The walk method should take a visitor, plus a variadic tail of arguments
to forward along. The context is one such "forwarded" argument.

Giving the context "pride of place" at the front of the argument list
makes the visitation/walk API less general. If I want to just print the
slots in an object, using a functor, why do I need to provide a context?